### PR TITLE
Forking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A template repository that Coachable students will use in the program for Leetco
 - Fork this repository. On the top right of the main page of this repository, click on `Fork`.
 - Follow the convention for the naming of the repo: 
   - `Coachable-[First Name]-[Last Name]-Repository`
-- Add your list of coaches (link TBA) as collaborators to your private forked repository, granting access for review and feedback.
+- Add the list of coaches (aaguasvivas, CoachTimVan, darekj28) as collaborators to your private forked repository, granting access for review and feedback.
   - Example: https://stackoverflow.com/a/64682846/24669812
 - [IMPORTANT] Replace the coach in [`.github/CODEOWNERS`](https://github.com/Coachable-Dev/coachable-student-github-template/blob/main/.github/CODEOWNERS#L1) with your designated coach. This will ensure timely notifications when a Pull Request (PR) is made.
 
@@ -17,5 +17,6 @@ A template repository that Coachable students will use in the program for Leetco
 - Commits must be made to a separate branch (a feature branch), and not the main branch. Pull Requests (PRs) will be made to merge into the main branch. This will allow coaches to review your code and submissions. [Example](https://github.com/Coachable-Dev/coachable-student-github-template/commits/2024-11-13-submission).
 - [**IMPORTANT**] [**WARNING**] When making a PR, ensure that the main branch that your are merging into belong to YOUR fork! Failure to do so will result in your PR getting ***rejected***, and you will have to remake it.
 - PRs can consists of ***more than one problem*** and/or commit. However, ***each problem*** must include the leetcode problem number, loom link, and 2 - 3 word sentence summary within the PR message. Each problem must also be properly segmented with markdown, i.e. use seperators between each problem.
-  - [Example](https://github.com/Coachable-Dev/coachable-student-github-template/pull/1)
+  - [Single Problem PR Example](https://github.com/Coachable-Dev/coachable-student-github-template/pull/1)
+  - [Multi Problem PR Example](https://github.com/TimothyV97/coachable-student-github-template/pull/2)
   - [**IMPORTANT**] Please include your assigned coach as the reviewer of your PR. If you don't, your coach will not grade or review your PR because they will miss it.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Coachable Student Github Template 
+# Coachable Student Github Repository 
 A template repository that Coachable students will use in the program for Leetcode and other assignments.
 
 
 ## Instructions to setup student repositiory
-- On the top right of the main page of this repository, click on `Use this template` and `Create a new repository` on your Github account.
+- Fork this repository. On the top right of the main page of this repository, click on `Fork`.
 - Follow the convention for the naming of the repo: 
   - `Coachable-[First Name]-[Last Name]-Repository`
-- (Optional) Make the newly created repository private.
 - Add your list of coaches (link TBA) as collaborators to your private forked repository, granting access for review and feedback.
   - Example: https://stackoverflow.com/a/64682846/24669812
 - [IMPORTANT] Replace the coach in [`.github/CODEOWNERS`](https://github.com/Coachable-Dev/coachable-student-github-template/blob/main/.github/CODEOWNERS#L1) with your designated coach. This will ensure timely notifications when a Pull Request (PR) is made.
@@ -14,8 +13,9 @@ A template repository that Coachable students will use in the program for Leetco
 
 ## Leetcode Code submission instructions 
 - Commit messages must be the Leetcode problem, so that includes the problem number and problem title. [Example](https://github.com/Coachable-Dev/coachable-student-github-template/commit/72aca819a24053392f8ea2e93645233093f48450).
+- Each problem should have at least one commit dedicated to it's addition. i.e. when fixing a problem or addressing a change, ensure that it's a seperate commit.
 - Commits must be made to a separate branch (a feature branch), and not the main branch. Pull Requests (PRs) will be made to merge into the main branch. This will allow coaches to review your code and submissions. [Example](https://github.com/Coachable-Dev/coachable-student-github-template/commits/2024-11-13-submission).
-- PR messages must include the leetcode problem number, loom link, and 2 - 3 word sentence summary.
-  - If there are multiple commits(problems) per PR, then the PR must segment each Loom link and problem summary by Problem number using proper markdown (i.e. using separators in markdown to separate problems.)
+- [**IMPORTANT**] [**WARNING**] When making a PR, ensure that the main branch that your are merging into belong to YOUR fork! Failure to do so will result in your PR getting ***rejected***, and you will have to remake it.
+- PRs can consists of ***more than one problem*** and/or commit. However, ***each problem*** must include the leetcode problem number, loom link, and 2 - 3 word sentence summary within the PR message. Each problem must also be properly segmented with markdown, i.e. use seperators between each problem.
   - [Example](https://github.com/Coachable-Dev/coachable-student-github-template/pull/1)
-  - [IMPORTANT] Please include your assigned coach as the reviewer of your PR. If you don't, your coach will not grade or review your PR because they will miss it.
+  - [**IMPORTANT**] Please include your assigned coach as the reviewer of your PR. If you don't, your coach will not grade or review your PR because they will miss it.


### PR DESCRIPTION
Updated repository to use forking instructions instead of template instructions. Providing the coachable team with better control over forked repos, including propagating changes from the main fork to student forks.